### PR TITLE
[SCRUM-40] 회원가입시 회사 연관관계 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation('org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16')
-
+	testImplementation 'org.mockito:mockito-core:5.7.0'
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
 	//querydsl
 	//QueryDsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/example/demo/domain/company/Company.java
+++ b/src/main/java/example/demo/domain/company/Company.java
@@ -40,6 +40,12 @@ public class Company extends BaseEntity {
         this.companyDept = companyDept;
         this.invitationCode = invitationCode;
     }
+    public void addMember(Member member){
+        members.add(member);
+    }
+    public void setCompanyId(Long companyId){
+        this.companyId=companyId;
+    }
 
 }
 

--- a/src/main/java/example/demo/domain/company/repository/CompanyRepository.java
+++ b/src/main/java/example/demo/domain/company/repository/CompanyRepository.java
@@ -5,6 +5,9 @@ import example.demo.domain.company.repository.CompanyCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CompanyRepository extends JpaRepository<Company,Long> , CompanyCustomRepository {
+    Optional<Company> findByCompanyNameAndCompanyDept(String companyName,String companyDept);
 }

--- a/src/main/java/example/demo/domain/member/Member.java
+++ b/src/main/java/example/demo/domain/member/Member.java
@@ -82,4 +82,5 @@ public class Member extends BaseEntity {
     public void setPassword(String password) {
         this.password = password;
     }
+    public void setMemberId(Long memberId){this.memberId=memberId;}
 }

--- a/src/main/java/example/demo/domain/member/api/MemberServiceImpl.java
+++ b/src/main/java/example/demo/domain/member/api/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package example.demo.domain.member.api;
 
 import example.demo.data.RedisCustomService;
 import example.demo.domain.company.Company;
+import example.demo.domain.company.CompanyErrorCode;
 import example.demo.domain.company.repository.CompanyRepository;
 import example.demo.domain.company.dto.CompanyInfoWithUuidDto;
 import example.demo.domain.member.Member;
@@ -37,7 +38,7 @@ public class MemberServiceImpl implements MemberService {
     //회원가입 이전 : 이메일 인증, 휴대폰 인증 여부 확인.
     public void signup(MemberRequestDto memberRequestDto){
         Member newMember ;
-        Company newCompany;
+        Company company;
         //이메일 중복, 휴대폰번호 중복 예외처리는 해당 서비스 계층에서 실시합니다.
         //회원가입 전 이메일 인증 및 휴대폰 번호 인증 여부
         if(smsAndMailValidation(memberRequestDto.getEmail(),memberRequestDto.getPhoneNumber())){
@@ -53,13 +54,16 @@ public class MemberServiceImpl implements MemberService {
             case "manager":
                 //uuid생성
                 String companyCode= CreateRandom.createShortUuid();
-                newCompany=Company.builder()
-                        .companyName(memberRequestDto.getCompanyName())
-                        .companyDept(memberRequestDto.getCompanyDept())
-                        .invitationCode(companyCode)
-                        .build();
-                companyRepository.save(newCompany);
-                newMember=Member.createManager(memberRequestDto,newCompany);
+                company=companyRepository.findByCompanyNameAndCompanyDept(memberRequestDto.getCompanyName(),memberRequestDto.getCompanyDept())
+                                .orElse(
+                                        Company.builder()
+                                                .companyName(memberRequestDto.getCompanyName())
+                                                .companyDept(memberRequestDto.getCompanyDept())
+                                                .invitationCode(companyCode)
+                                                .build()
+                                );
+                companyRepository.save(company);
+                newMember=Member.createManager(memberRequestDto,company);
                 break;
             //직원
             case "employee":
@@ -67,12 +71,10 @@ public class MemberServiceImpl implements MemberService {
                 CompanyInfoWithUuidDto companyInfoWithUuidDto=companyRepository.findCompanyInfoByInvitationCode(memberRequestDto.getInvitationCode());
                 String companyName=companyInfoWithUuidDto.getCompanyName();
                 String companyDept=companyInfoWithUuidDto.getCompanyDept();
-                newCompany=Company.builder()
-                        .companyName(companyName)
-                        .companyDept(companyDept)
-                        .build();
-                companyRepository.save(newCompany);
-                newMember=Member.createEmployee(memberRequestDto,newCompany);
+                company=companyRepository.findByCompanyNameAndCompanyDept(companyName,companyDept)
+                                .orElseThrow(()->new RestApiException(CompanyErrorCode.NOT_EXIST_COMPANY));
+
+                newMember=Member.createEmployee(memberRequestDto,company);
                 break;
             default:
                 throw new RestApiException(MemberErrorCode.INVALID_MEMBER_STATUS);

--- a/src/test/java/example/demo/domain/company/CompanyCustomRepositoryImplTest.java
+++ b/src/test/java/example/demo/domain/company/CompanyCustomRepositoryImplTest.java
@@ -86,4 +86,21 @@ class CompanyCustomRepositoryImplTest {
         //assertThat(codeDto.getCompanyCode()).isEqualTo(uuid);
 
     }
+    @Test
+    @DisplayName("회사명과 회사부서명으로 회사를 찾습니다.")
+    void findByCompanyNameAndCompanyDept(){
+        //given
+        Company company=Company.builder()
+                .companyName("삼성")
+                .companyDept("개발")
+                .invitationCode(null)
+                .build();
+        companyRepository.save(company);
+        //when
+        Company findCompany=companyRepository.findByCompanyNameAndCompanyDept("삼성","개발").orElseThrow();
+
+        //then
+        assertThat(findCompany).extracting("companyName","companyDept","invitationCode")
+                .containsExactly(company.getCompanyName(),company.getCompanyDept(),company.getInvitationCode());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#33 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- EMPLOYEE 유형의 회원이 가입 시 회사코드로 기존 회사와의 연관관계 설정
- MemberServiceImp의 signup 메서드 코드 수정 및 테스트 코드 작성, 검증

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
