### PR TITLE
[SCRUM-56] 최신 대화방 4개 및 Preview 불러오기 & 유저당 대화방 생성 제한

### DIFF
--- a/src/main/java/example/demo/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/example/demo/domain/chat/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package example.demo.domain.chat.controller;
 
 import example.demo.domain.chat.dto.ChatDto;
+import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
 import example.demo.domain.chat.dto.ChatRoomRequestDto;
 import example.demo.domain.chat.dto.ChatRoomResponseDto;
 import example.demo.domain.chat.service.ChatRoomService;
@@ -28,9 +29,10 @@ public class ChatRoomController {
         return ResponseEntity.ok(chatRoom);
     }
 
-    @GetMapping("/get")
-    public ResponseEntity<?> getChatList(@Valid @RequestBody ChatRoomRequestDto requestDto) {
-        List<ChatDto> messages = chatRoomService.getChatListByChatRoomId(requestDto.getChatRoomId());
-        return ResponseEntity.ok(messages);
+    @GetMapping("/latest")
+    public ResponseEntity<?> getLatestChatRoom(@RequestHeader("Authorization") String token) {
+        Long memberId = jwtUtil.getMemberId(token);
+        List<ChatRoomRecentResponseDto> latestChatRoom = chatRoomService.getLatestChatRoom(memberId);
+        return ResponseEntity.ok(latestChatRoom);
     }
 }

--- a/src/main/java/example/demo/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/example/demo/domain/chat/controller/ChatRoomController.java
@@ -1,12 +1,9 @@
 package example.demo.domain.chat.controller;
 
-import example.demo.domain.chat.dto.ChatDto;
 import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
-import example.demo.domain.chat.dto.ChatRoomRequestDto;
 import example.demo.domain.chat.dto.ChatRoomResponseDto;
 import example.demo.domain.chat.service.ChatRoomService;
 import example.demo.security.util.JwtUtil;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/example/demo/domain/chat/dto/ChatRoomRecentResponseDto.java
+++ b/src/main/java/example/demo/domain/chat/dto/ChatRoomRecentResponseDto.java
@@ -1,0 +1,20 @@
+package example.demo.domain.chat.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomRecentResponseDto {
+
+    private Long chatRoomId;
+
+    private String latestAnswer;
+
+    @Builder
+    @QueryProjection
+    public ChatRoomRecentResponseDto(Long chatRoomId, String latestAnswer) {
+        this.chatRoomId = chatRoomId;
+        this.latestAnswer = latestAnswer;
+    }
+}

--- a/src/main/java/example/demo/domain/chat/dto/ChatRoomRequestDto.java
+++ b/src/main/java/example/demo/domain/chat/dto/ChatRoomRequestDto.java
@@ -1,12 +1,24 @@
 package example.demo.domain.chat.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoomRequestDto {
 
     private Long chatRoomId;
+    private LocalDateTime createdAt;
+
+    @Builder
+    @QueryProjection
+    public ChatRoomRequestDto(Long chatRoomId, LocalDateTime createdAt) {
+        this.chatRoomId = chatRoomId;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/example/demo/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/example/demo/domain/chat/repository/ChatRepository.java
@@ -1,9 +1,13 @@
 package example.demo.domain.chat.repository;
 
 import example.demo.domain.chat.Chat;
+import example.demo.domain.chat.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long>, ChatRepositoryCustom {
+    List<Chat> findByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/example/demo/domain/chat/repository/ChatRepositoryCustom.java
+++ b/src/main/java/example/demo/domain/chat/repository/ChatRepositoryCustom.java
@@ -5,5 +5,4 @@ import example.demo.domain.chat.Chat;
 import java.util.Optional;
 
 public interface ChatRepositoryCustom {
-    Optional<Chat> findChatListByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/example/demo/domain/chat/repository/ChatRepositoryCustomImpl.java
+++ b/src/main/java/example/demo/domain/chat/repository/ChatRepositoryCustomImpl.java
@@ -18,14 +18,4 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
     public ChatRepositoryCustomImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
     }
-
-    @Override
-    public Optional<Chat> findChatListByChatRoomId(Long chatRoomId) {
-        return Optional.ofNullable(queryFactory
-                .selectFrom(chat)
-                .where(chat.chatRoom.chatRoomId.eq(chatRoomId))
-                .orderBy(chat.createdAt.desc())
-                .fetchFirst());
-    }
-
 }

--- a/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,4 +1,9 @@
 package example.demo.domain.chat.repository;
 
+import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
+
+import java.util.List;
+
 public interface ChatRoomRepositoryCustom {
+    List<ChatRoomRecentResponseDto> findLatestChatRoomWithLatestAnswer(Long memberId);
 }

--- a/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,9 +1,12 @@
 package example.demo.domain.chat.repository;
 
 import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
+import example.demo.domain.chat.dto.ChatRoomRequestDto;
 
 import java.util.List;
 
 public interface ChatRoomRepositoryCustom {
     List<ChatRoomRecentResponseDto> findLatestChatRoomWithLatestAnswer(Long memberId);
+
+    List<ChatRoomRequestDto> findByMemberOrderByCreatedAtAsc(Long memberId);
 }

--- a/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -1,10 +1,16 @@
 package example.demo.domain.chat.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import example.demo.domain.chat.QChatRoom;
+import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
+import example.demo.domain.chat.dto.QChatRoomRecentResponseDto;
 import example.demo.domain.chat.dto.QChatRoomResponseDto;
 import jakarta.persistence.EntityManager;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import static com.querydsl.jpa.JPAExpressions.*;
 import static example.demo.domain.chat.QChat.chat;
 import static example.demo.domain.chat.QChatRoom.*;
 
@@ -16,4 +22,45 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
+    @Override
+    public List<ChatRoomRecentResponseDto> findLatestChatRoomWithLatestAnswer(Long memberId) {
+        List<Long> latestChatRoomIds = getLatestChatRoomIds(memberId);
+
+        return latestChatRoomIds.stream()
+                .map(this::getChatRoomRecentResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+        return memberId != null ? chatRoom.member.memberId.eq(memberId) : null;
+    }
+
+    private static BooleanExpression chatRoomIdEq(Long chatRoomId) {
+        return chatRoomId != null ? chat.chatRoom.chatRoomId.eq(chatRoomId) : null;
+    }
+
+    private List<Long> getLatestChatRoomIds(Long memberId) {
+        return queryFactory
+                .select(chatRoom.chatRoomId)
+                .from(chatRoom)
+                .where(memberIdEq(memberId))
+                .orderBy(chatRoom.createdAt.desc())
+                .limit(4)
+                .fetch();
+    }
+
+    private ChatRoomRecentResponseDto getChatRoomRecentResponseDto(Long chatRoomId) {
+        String latestAnswer = getLatestAnswer(chatRoomId);
+        return new ChatRoomRecentResponseDto(chatRoomId, latestAnswer);
+    }
+
+    private String getLatestAnswer(Long chatRoomId) {
+        return queryFactory
+                .select(chat.answer)
+                .from(chat)
+                .where(chatRoomIdEq(chatRoomId))
+                .orderBy(chat.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+    }
 }

--- a/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/example/demo/domain/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -2,10 +2,9 @@ package example.demo.domain.chat.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import example.demo.domain.chat.ChatRoom;
 import example.demo.domain.chat.QChatRoom;
-import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
-import example.demo.domain.chat.dto.QChatRoomRecentResponseDto;
-import example.demo.domain.chat.dto.QChatRoomResponseDto;
+import example.demo.domain.chat.dto.*;
 import jakarta.persistence.EntityManager;
 
 import java.util.List;
@@ -29,6 +28,18 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
         return latestChatRoomIds.stream()
                 .map(this::getChatRoomRecentResponseDto)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ChatRoomRequestDto> findByMemberOrderByCreatedAtAsc(Long memberId) {
+        return queryFactory
+                .select(new QChatRoomRequestDto(chatRoom.chatRoomId,
+                        chatRoom.createdAt)
+                )
+                .from(chatRoom)
+                .where(memberIdEq(memberId))
+                .orderBy(chatRoom.createdAt.asc())
+                .fetch();
     }
 
     private BooleanExpression memberIdEq(Long memberId) {

--- a/src/main/java/example/demo/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/example/demo/domain/chat/service/ChatRoomService.java
@@ -1,6 +1,6 @@
 package example.demo.domain.chat.service;
 
-import example.demo.domain.chat.dto.ChatDto;
+import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
 import example.demo.domain.chat.dto.ChatRoomResponseDto;
 import org.springframework.stereotype.Service;
 
@@ -10,5 +10,5 @@ import java.util.List;
 public interface ChatRoomService {
     ChatRoomResponseDto createChatRoom(Long memberId);
 
-    List<ChatDto> getChatListByChatRoomId(Long chatRoomId);
+    List<ChatRoomRecentResponseDto> getLatestChatRoom(Long memberId);
 }

--- a/src/main/java/example/demo/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/example/demo/domain/chat/service/ChatRoomServiceImpl.java
@@ -25,7 +25,6 @@ import java.util.List;
 public class ChatRoomServiceImpl implements ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatRepository chatRepository;
     private final MemberRepository memberRepository;
     private static final int MAX_CHAT_ROOM_COUNT = 7;
 
@@ -65,8 +64,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private void deleteChatRoomAndChatList(Long chatRoomId) {
         ChatRoom result = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
-        List<Chat> chatList = chatRepository.findByChatRoom(result);
-        chatRepository.deleteAll(chatList);
         chatRoomRepository.delete(result);
     }
 }

--- a/src/main/java/example/demo/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/example/demo/domain/chat/service/ChatRoomServiceImpl.java
@@ -2,8 +2,8 @@ package example.demo.domain.chat.service;
 
 import example.demo.domain.chat.Chat;
 import example.demo.domain.chat.ChatRoom;
-import example.demo.domain.chat.ChatRoomErrorCode;
 import example.demo.domain.chat.dto.ChatDto;
+import example.demo.domain.chat.dto.ChatRoomRecentResponseDto;
 import example.demo.domain.chat.dto.ChatRoomResponseDto;
 import example.demo.domain.chat.repository.ChatRepository;
 import example.demo.domain.chat.repository.ChatRoomRepository;
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -43,22 +42,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
-    public List<ChatDto> getChatListByChatRoomId(Long chatRoomId) {
-        if (!chatRoomRepository.existsById(chatRoomId)) {
-            throw new RestApiException(ChatRoomErrorCode.CHAT_ROOM_NOT_FOUND);
+    public List<ChatRoomRecentResponseDto> getLatestChatRoom(Long memberId) {
+        List<ChatRoomRecentResponseDto> latestChatRoom = chatRoomRepository.findLatestChatRoomWithLatestAnswer(memberId);
+        if (latestChatRoom.isEmpty()) {
+            return Collections.emptyList();
         }
-        Optional<Chat> optionalChat = chatRepository.findChatListByChatRoomId(chatRoomId);
-        Chat chat = optionalChat.get();
-        return Collections.singletonList(convertToDto(chat));
-    }
-
-    private ChatDto convertToDto(Chat chat) {
-        return ChatDto.builder()
-                .chatId(chat.getChatId())
-                .modelType(chat.getModelType())
-                .question(chat.getQuestion())
-                .answer(chat.getAnswer())
-                .chatRoomId(chat.getChatRoom().getChatRoomId())
-                .build();
+        return latestChatRoom;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

### **메인 기능 1**
#### 유저 ID를 기준으로 대화방 Entity에서 최신 4개의 ChatRoomId를 가져오도록 Query 작성
#### 위에서 가져온 최신 4개의 ChatRoomId에 해당하는 가장 최신 대화(Answer)내용 1개를 가져오도록 Query 작성
#### 이 후, DTO로 ChatRoomId와 Answer 반환
---
### **메인 기능 2**
#### 유저 ID를 기준으로 `MAX_CHAT_ROOM_COUNT`보다 초과할 시, 가장 마지막에 생성된 채팅방과 채팅 내역을 전부 삭제
#### 채팅 내용이 전부 사라지는 문제점이 있지만 메모리 성능상 문제로 인해 이를 프론트에서 사용자에게 알릴 필요가 있음.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 생각보다 `Chaining`이 길어져서 `Method`로 추출한 부분이 많습니다. 그래도 기능에 맞는 `Naming`으로 추출해서 사용했는데 혹시 이해가 잘 안되는 부분이 있으면 말씀해주세요🙂
