### PR TITLE
[SCRUM-57] 회원 비밀번호 수정 / 로그인 5회 초과 시 계정 일시 차단

### DIFF
--- a/src/main/java/example/demo/common/ResponseDto.java
+++ b/src/main/java/example/demo/common/ResponseDto.java
@@ -1,0 +1,18 @@
+package example.demo.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@ToString
+public class ResponseDto {
+    private final Boolean success;
+    private final Integer code;
+    private final String message;
+
+    public static ResponseDto of(Boolean success, Integer code,String message){
+        return new ResponseDto(success,code,message);
+    }
+}

--- a/src/main/java/example/demo/data/RedisCustomService.java
+++ b/src/main/java/example/demo/data/RedisCustomService.java
@@ -8,4 +8,5 @@ public interface RedisCustomService {
     void deleteRedisData(String key);
     boolean hasKey(String key);
     Set<String> getKeysByPattern(String pattern);
+    Long getRemainingTime(String key);
 }

--- a/src/main/java/example/demo/data/RedisCustomServiceImpl.java
+++ b/src/main/java/example/demo/data/RedisCustomServiceImpl.java
@@ -43,4 +43,10 @@ public class RedisCustomServiceImpl implements RedisCustomService{
     public Set<String> getKeysByPattern(String pattern) {
         return redisTemplate.keys(pattern);
     }
+
+    //남은 TTL 가져오기
+    @Override
+    public Long getRemainingTime(String key) {
+        return redisTemplate.getExpire(key,TimeUnit.MILLISECONDS);
+    }
 }

--- a/src/main/java/example/demo/domain/member/Member.java
+++ b/src/main/java/example/demo/domain/member/Member.java
@@ -44,9 +44,6 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "company_id")
     private Company company;
 
-    //계정 로그인 시도 횟수
-    @Column(name = "failed_attemps",columnDefinition = "INT DEFAULT 0")
-    private int failedAttempts;
     public Member(String email, String userName, String password, MemberStatus memberStatus, String phoneNumber, String companyPosition,Company company) {
         this.email = email;
         this.userName = userName;
@@ -87,8 +84,4 @@ public class Member extends BaseEntity {
     }
     public void setMemberId(Long memberId){this.memberId=memberId;}
 
-    //로그인 실패 횟수 증가
-    public void incrementFailedAttempts(){
-        this.failedAttempts++;
-    }
 }

--- a/src/main/java/example/demo/domain/member/Member.java
+++ b/src/main/java/example/demo/domain/member/Member.java
@@ -37,13 +37,16 @@ public class Member extends BaseEntity {
     private String companyPosition;
 
     //계정 잠금 여부
-    @Column(name = "account_locked")
+    @Column(name = "account_locked",columnDefinition = "BOOLEAN DEFAULT false")
     private boolean accountLocked;
     //Company랑 양방향
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id")
     private Company company;
 
+    //계정 로그인 시도 횟수
+    @Column(name = "failed_attemps",columnDefinition = "INT DEFAULT 0")
+    private int failedAttempts;
     public Member(String email, String userName, String password, MemberStatus memberStatus, String phoneNumber, String companyPosition,Company company) {
         this.email = email;
         this.userName = userName;
@@ -83,4 +86,9 @@ public class Member extends BaseEntity {
         this.password = password;
     }
     public void setMemberId(Long memberId){this.memberId=memberId;}
+
+    //로그인 실패 횟수 증가
+    public void incrementFailedAttempts(){
+        this.failedAttempts++;
+    }
 }

--- a/src/main/java/example/demo/security/auth/AuthErrorCode.java
+++ b/src/main/java/example/demo/security/auth/AuthErrorCode.java
@@ -12,10 +12,10 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_EMAIL_OR_PASSWORD(HttpStatus.NOT_FOUND,"이메일 또는 비밀번호가 일치하지 않습니다."),
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND,"유저가 존재하지 않습니다."),
     EXCEED_LOGIN(HttpStatus.UNAUTHORIZED,"로그인 횟수를 5회 초과했습니다.잠시 후 다시 시도해주세요."),
-    ACCOUNT_LOCKED(HttpStatus.LOCKED,"계정이 잠겼습니다.관리자에게 문의해주세요."),
     NO_AUTHORITIES(HttpStatus.FORBIDDEN,"권한이 없습니다."),
     NOT_AUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED,"인증된 유저가 아닙니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_GATEWAY,"유효하지 않은 리프레시 토큰값입니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_GATEWAY,"유효하지 않은 리프레시 토큰값입니다."),
+    LOCKED_ACCOUT(HttpStatus.LOCKED,"로그인 5회 초과로 계정이 잠겼습니다. \n관리자에게 문의하세요.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/example/demo/security/auth/AuthErrorCode.java
+++ b/src/main/java/example/demo/security/auth/AuthErrorCode.java
@@ -11,7 +11,7 @@ public enum AuthErrorCode implements ErrorCode {
     NOT_EXIST_EMAIL(HttpStatus.NOT_FOUND,"이메일이 존재하지 않습니다."),
     INVALID_EMAIL_OR_PASSWORD(HttpStatus.NOT_FOUND,"이메일 또는 비밀번호가 일치하지 않습니다."),
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND,"유저가 존재하지 않습니다."),
-    EXCEED_LOGIN(HttpStatus.UNAUTHORIZED,"로그인 횟수를 5회 초과했습니다.잠시 후 다시 시도해주세요."),
+    EXCEED_LOGIN(HttpStatus.UNAUTHORIZED,"로그인 횟수를 5회 초과했습니다.30분 후 다시 시도해주세요."),
     NO_AUTHORITIES(HttpStatus.FORBIDDEN,"권한이 없습니다."),
     NOT_AUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED,"인증된 유저가 아닙니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_GATEWAY,"유효하지 않은 리프레시 토큰값입니다."),

--- a/src/main/java/example/demo/security/auth/CustomMemberDetailService.java
+++ b/src/main/java/example/demo/security/auth/CustomMemberDetailService.java
@@ -17,8 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomMemberDetailService implements UserDetailsService {
     private final MemberRepository memberRepository;
     @Override
-    public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
-        Member member=memberRepository.findById(Long.parseLong(memberId))
+    public CustomMemberDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member=memberRepository.findByEmail(email)
                 .orElseThrow(()->new RestApiException(AuthErrorCode.NOT_EXIST_MEMBER));
         CustomMemberInfoDto dto=CustomMemberInfoDto.builder()
                 .email(member.getEmail())

--- a/src/main/java/example/demo/security/auth/api/AuthApiController.java
+++ b/src/main/java/example/demo/security/auth/api/AuthApiController.java
@@ -38,7 +38,7 @@ public class AuthApiController {
         return ResponseEntity.ok(accessTokenResponseDto);
     }
 
-    @PutMapping("change-passowd")
+    @PutMapping("change-password")
     public ResponseEntity<?> changePassword(@Validated(ValidationSequence.class) @RequestBody ChangePasswordRequestDto requestDto,
                                             @RequestHeader("Authorization")String token){
         authService.changePassword(token,requestDto);

--- a/src/main/java/example/demo/security/auth/api/AuthApiController.java
+++ b/src/main/java/example/demo/security/auth/api/AuthApiController.java
@@ -1,9 +1,11 @@
 package example.demo.security.auth.api;
 
+import example.demo.common.ResponseDto;
 import example.demo.domain.member.MemberErrorCode;
 import example.demo.error.RestApiException;
 import example.demo.security.auth.AuthErrorCode;
 import example.demo.security.auth.dto.AccessTokenResponseDto;
+import example.demo.security.auth.dto.ChangePasswordRequestDto;
 import example.demo.security.auth.dto.MemberLoginDto;
 import example.demo.util.ValidationSequence;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,5 +36,12 @@ public class AuthApiController {
         }
         AccessTokenResponseDto accessTokenResponseDto= authService.refreshAccessToken(refreshToken,response);
         return ResponseEntity.ok(accessTokenResponseDto);
+    }
+
+    @PutMapping("change-passowd")
+    public ResponseEntity<?> changePassword(@Validated(ValidationSequence.class) @RequestBody ChangePasswordRequestDto requestDto,
+                                            @RequestHeader("Authorization")String token){
+        authService.changePassword(token,requestDto);
+        return ResponseEntity.ok(ResponseDto.of(true,200,"비밀번호 변경 성공"));
     }
 }

--- a/src/main/java/example/demo/security/auth/api/AuthService.java
+++ b/src/main/java/example/demo/security/auth/api/AuthService.java
@@ -1,10 +1,14 @@
 package example.demo.security.auth.api;
 
+import example.demo.common.ResponseDto;
 import example.demo.security.auth.dto.AccessTokenResponseDto;
+import example.demo.security.auth.dto.ChangePasswordRequestDto;
 import example.demo.security.auth.dto.MemberLoginDto;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
     AccessTokenResponseDto loginMember(MemberLoginDto loginDto, HttpServletResponse response);
     AccessTokenResponseDto refreshAccessToken(String refreshToken,HttpServletResponse response);
+    //회원정보-비밀번호 수정
+    void changePassword(String token, ChangePasswordRequestDto requestDto);
 }

--- a/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
+++ b/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
@@ -41,6 +41,11 @@ public class AuthServiceImpl implements AuthService {
             throw new RestApiException(AuthErrorCode.INVALID_EMAIL_OR_PASSWORD);
         }
 
+        //계정 잠금 유무 확인
+        if(findMember.isAccountLocked()){
+            throw new RestApiException(AuthErrorCode.LOCKED_ACCOUT);
+        }
+
         CustomMemberInfoDto infoDto = new CustomMemberInfoDto(
                 findMember.getMemberId(), email, password, findMember.getMemberStatus(), findMember.isAccountLocked()
         );

--- a/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
+++ b/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
@@ -47,7 +47,11 @@ public class AuthServiceImpl implements AuthService {
         }
 
         CustomMemberInfoDto infoDto = new CustomMemberInfoDto(
-                findMember.getMemberId(), email, password, findMember.getMemberStatus(), findMember.isAccountLocked()
+                findMember.getMemberId(),
+                email,
+                password,
+                findMember.getMemberStatus(),
+                false
         );
         //기존 refresh 삭제
         refresh.removeUserRefreshToken(infoDto.getMemberId());

--- a/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
+++ b/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -109,6 +110,7 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
+    @Transactional
     @Override
     public void changePassword(String token, ChangePasswordRequestDto requestDto) {
         Member findMember = memberRepository.findById(jwtUtil.getMemberId(token))

--- a/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
+++ b/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
@@ -116,9 +116,9 @@ public class AuthServiceImpl implements AuthService {
         /*
          *유저 아이디와 비밀번호 일치 체크
          */
-        String newPassword = encoder.encode(requestDto.getPassword());
+        String newPassword = encoder.encode(requestDto.getNewPassword());
         if (!findMember.getEmail().equals(requestDto.getEmail()) ||
-                !encoder.matches(findMember.getPassword(), newPassword)
+                !encoder.matches(encoder.encode(requestDto.getPassword()), findMember.getPassword())
         ) {
             throw new RestApiException(AuthErrorCode.INVALID_EMAIL_OR_PASSWORD);
         }

--- a/src/main/java/example/demo/security/auth/dto/ChangePasswordRequestDto.java
+++ b/src/main/java/example/demo/security/auth/dto/ChangePasswordRequestDto.java
@@ -1,0 +1,14 @@
+package example.demo.security.auth.dto;
+
+import example.demo.util.ValidationGroups;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public class ChangePasswordRequestDto extends MemberLoginDto{
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.",
+            groups = ValidationGroups.NotEmptyGroup.class)
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+            message = "잘못된 비밀번호 형식입니다.",
+            groups = ValidationGroups.PatternCheckGroup.class)
+    private String newPassword;
+}

--- a/src/main/java/example/demo/security/auth/dto/ChangePasswordRequestDto.java
+++ b/src/main/java/example/demo/security/auth/dto/ChangePasswordRequestDto.java
@@ -3,7 +3,10 @@ package example.demo.security.auth.dto;
 import example.demo.util.ValidationGroups;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class ChangePasswordRequestDto extends MemberLoginDto{
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.",
             groups = ValidationGroups.NotEmptyGroup.class)
@@ -11,4 +14,16 @@ public class ChangePasswordRequestDto extends MemberLoginDto{
             message = "잘못된 비밀번호 형식입니다.",
             groups = ValidationGroups.PatternCheckGroup.class)
     private String newPassword;
+
+    @Builder
+    public ChangePasswordRequestDto (@NotBlank(message = "이메일은 필수 입력 값입니다.",
+            groups = ValidationGroups.NotEmptyGroup.class) @Pattern(regexp = "^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+            message = "잘못된 이메일 입력입니다.",
+            groups = ValidationGroups.PatternCheckGroup.class
+    ) String email,String password,String newPassword){
+        super(email,password);
+        this.newPassword=newPassword;
+    }
 }
+
+

--- a/src/main/java/example/demo/security/auth/dto/CustomMemberInfoDto.java
+++ b/src/main/java/example/demo/security/auth/dto/CustomMemberInfoDto.java
@@ -12,6 +12,8 @@ public class CustomMemberInfoDto extends MemberLoginDto {
     private Long memberId;
     private MemberStatus memberStatus;
     private boolean accountLocked;
+    //로그인 실패 횟수
+    private int failedAttempts;
 
     @Builder
     public CustomMemberInfoDto(Long memberId,@NotBlank(message = "이메일은 필수 입력 값입니다.",

--- a/src/main/java/example/demo/security/auth/dto/CustomMemberInfoDto.java
+++ b/src/main/java/example/demo/security/auth/dto/CustomMemberInfoDto.java
@@ -5,6 +5,7 @@ import example.demo.util.ValidationGroups;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 public class CustomMemberInfoDto extends MemberLoginDto {

--- a/src/main/java/example/demo/security/config/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/example/demo/security/config/CustomAuthenticationFailureHandler.java
@@ -22,22 +22,20 @@ import java.io.IOException;
 @Slf4j(topic = "FAILURE_HANDLER")
 @AllArgsConstructor
 @Component
-public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+public class CustomAuthenticationFailureHandler{
     ///최대 실패 횟수
     private static final int MAX_FAILED_ATTEMPTS=5;
 
     //잠금 시간(30분)
-    private static final long LOCK_TIME=1800000;
+    private static final long LOCK_TIME=1800;
     //로그인 시도 시간(10분)
-    private static final long ATTEMPT_TIME=600000;
+    private static final long ATTEMPT_TIME=600;
     private final RedisCustomService redisCustomService;
     private final String PREFIX="login :";
 
 
-    @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        String userEmail=request.getParameter("email");
 
+    public void filteringLoginAttempts(String userEmail)  {
         /*
         * 유저의 락 정보는 로그인 서비스단에서 조회
         * failureHandler는 로그인 실패 시 실패 횟수 추적만 하면됨

--- a/src/main/java/example/demo/security/config/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/example/demo/security/config/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,72 @@
+package example.demo.security.config;
+
+import example.demo.data.RedisCustomService;
+import example.demo.domain.member.repository.MemberRepository;
+import example.demo.error.RestApiException;
+import example.demo.security.auth.AuthErrorCode;
+import example.demo.security.auth.CustomMemberDetailService;
+import example.demo.security.auth.CustomMemberDetails;
+import example.demo.security.auth.dto.CustomMemberInfoDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+@Slf4j(topic = "FAILURE_HANDLER")
+@AllArgsConstructor
+@Component
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    ///최대 실패 횟수
+    private static final int MAX_FAILED_ATTEMPTS=5;
+
+    //잠금 시간(30분)
+    private static final long LOCK_TIME=1800000;
+    //로그인 시도 시간(10분)
+    private static final long ATTEMPT_TIME=600000;
+    private final RedisCustomService redisCustomService;
+    private final String PREFIX="login :";
+
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String userEmail=request.getParameter("email");
+
+        /*
+        * 유저의 락 정보는 로그인 서비스단에서 조회
+        * failureHandler는 로그인 실패 시 실패 횟수 추적만 하면됨
+        * */
+        //Redis에 값이 존재하는 경우
+        if(redisCustomService.hasKey(PREFIX+userEmail)){
+            int failedAttempts= Integer.parseInt(redisCustomService.getRedisData(PREFIX+userEmail))+1;
+            //5회 초과시
+            if (failedAttempts>MAX_FAILED_ATTEMPTS){
+                //Lock 시간 설정
+                redisCustomService.saveRedisData(PREFIX+userEmail, String.valueOf(failedAttempts),LOCK_TIME);
+                //로그인 횟수 초과 시 예외
+                throw new RestApiException(AuthErrorCode.EXCEED_LOGIN);
+            }
+
+            //5회 초과 미만
+            long time=redisCustomService.getRemainingTime(PREFIX+userEmail);
+
+            //TTL 만료 시
+            if(time<=0){
+                redisCustomService.saveRedisData(PREFIX+userEmail,"1",ATTEMPT_TIME);
+            }else {
+                //이전 값 삭제
+                redisCustomService.deleteRedisData(PREFIX+userEmail);
+                redisCustomService.saveRedisData(PREFIX+userEmail,String.valueOf(failedAttempts),time);
+            }
+        }else {
+            //Redis에 값이 존재하지 않는 경우
+            redisCustomService.saveRedisData(PREFIX+userEmail,"1",ATTEMPT_TIME);
+        }
+    }
+}

--- a/src/main/java/example/demo/security/config/SecurityConfig.java
+++ b/src/main/java/example/demo/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package example.demo.security.config;
 
+import example.demo.data.RedisCustomService;
 import example.demo.domain.member.MemberStatus;
 import example.demo.security.auth.CustomMemberDetailService;
 import example.demo.security.util.JwtAuthFilter;
@@ -28,10 +29,9 @@ import java.util.List;
 @AllArgsConstructor
 public class SecurityConfig {
     private final CustomMemberDetailService customMemberDetailService;
-    private final JwtUtil jwtUtil;
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
-
+    private final JwtUtil jwtUtil;
     private static final String[] AUTH_WHITELIST={
             "/api/login","/swagger-ui/**","/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html","/api/signup","/api/mail-send",

--- a/src/test/java/example/demo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/example/demo/domain/member/api/MemberControllerTest.java
@@ -60,5 +60,4 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.companyPosition").value("사장"));
     }
 
-
 }

--- a/src/test/java/example/demo/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/example/demo/domain/member/repository/MemberRepositoryTest.java
@@ -53,7 +53,7 @@ class MemberRepositoryTest {
         memberRepository.save(member);
 
         //when
-        Member findMember=memberRepository.findByEmail(member.getEmail()).get();
+        Member findMember=memberRepository.findByEmail(general.getEmail()).get();
 
         //then
         isSameMember(findMember, member);

--- a/src/test/java/example/demo/security/auth/api/AuthApiControllerTest.java
+++ b/src/test/java/example/demo/security/auth/api/AuthApiControllerTest.java
@@ -1,0 +1,57 @@
+package example.demo.security.auth.api;
+
+import example.demo.security.auth.dto.ChangePasswordRequestDto;
+import kotlinx.serialization.json.Json;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthApiControllerTest {
+
+    @MockitoBean
+    private AuthService authService;
+
+    @Autowired
+    private AuthApiController authApiController;
+
+    @Autowired
+    private MockMvc mvc;
+    @Test
+    @DisplayName("[PUT]-비밀번호 성공 시 ResponseDto를 반환합니다.")
+    void changePassword() throws Exception {
+        //given
+        String token="token";
+        ChangePasswordRequestDto requestDto=ChangePasswordRequestDto
+                .builder()
+                .password("tkv0123")
+                .newPassword("tkv00@@@!!")
+                .email("tkv00@naver.com")
+                .build();
+
+        doNothing().when(authService).changePassword(eq(token),eq(requestDto));
+        //when
+        //then
+        mvc.perform(put("/api/auth/change-password")
+                .header("Authorization",token)
+                        .contentType("application/json")
+                        .content("{\"email\": \"tkv00@naver.com\", \"password\": \"tkv0123!!\", \"newPassword\": \"tkv99@@@\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("비밀번호 변경 성공"));
+
+    }
+}

--- a/src/test/java/example/demo/security/auth/api/AuthServiceImplTest.java
+++ b/src/test/java/example/demo/security/auth/api/AuthServiceImplTest.java
@@ -1,0 +1,65 @@
+package example.demo.security.auth.api;
+
+import example.demo.domain.member.Member;
+import example.demo.domain.member.dto.request.MemberRequestDto;
+import example.demo.domain.member.repository.MemberRepository;
+import example.demo.security.auth.dto.ChangePasswordRequestDto;
+import example.demo.security.util.JwtUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@SpringBootTest
+
+class AuthServiceImplTest {
+    @Autowired
+    private AuthService authService;
+
+    @MockitoBean
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder encoder;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+    @Test
+    @DisplayName("[성공케이스]-회원의 비밀번호를 변경합니다.")
+    void changePassword() {
+        //given
+        MemberRequestDto requestDto=MemberRequestDto.ofGeneral(
+                "tkv00@naver.com","김도연","rlaehdus00!!","01012345678","GENERAL"
+        );
+
+        Member member=Member.createGeneral(requestDto);
+        member=memberRepository.save(member);
+        String token="token";
+
+        ChangePasswordRequestDto passwordRequestDto= (ChangePasswordRequestDto) ChangePasswordRequestDto
+                .builder()
+                .newPassword("rlaehdus00123!!")
+                .email(requestDto.getEmail())
+                .password(requestDto.getPassword())
+                .build();
+
+        //when
+        //비밀번호 변경
+        authService.changePassword(token,passwordRequestDto);
+        when(jwtUtil.getMemberId(token)).thenReturn(member.getMemberId());
+
+        //then
+        Member newPasswordMember=memberRepository.findById(member.getMemberId()).orElseThrow();
+        assertThat(encoder.matches(newPasswordMember.getPassword(),
+                encoder.encode(passwordRequestDto.getPassword()))).isTrue();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
- `Redis`를 이용하여 회원이 로그인 시 존재하는 이메일 유무 확인->
  - 존재O
    1.  `Redis`에 키값으로 유저의 이메일을, 밸류값으로 로그인 횟수 시도를 저장(만료 시간도 저장)=>10분동안 로그인 시도
    2. 로그인 시도 기록이 없으면 0값 삽입
    3. 로그인 시도 기록이 존재하면 시도 횟수 1씩 증가
    4. 로그인 5회 초과 시 30분동안 계정 일시 정지
  - 존재X
    1. `RestApiException`으로 `유저의 아이디 혹은 비밀번호가 존재하지 않습니다` 예외를 던짐

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 사실 스프링 시큐리티의 이점을 사용하여 로그인 하는 시점, 컨트롤러에 값 삽입이전에 beforeFiltering를 통해 로그인 횟수 검증을 구현하려 했으나 `formlogin`에서 주로 사용하는 방법으로 현재 프로젝트에 사용되는 `JWT`방식에서는 사용하기 까다롭다.
- 과연 다른 클래스에서 생성자 주입을 통해 `AuthServiceImpl`에서 직접 사용되는 방식이 각 클래스간 관심사 분할의 문제가 발생하지 않을까하는 생각... 즉 결합도를 낮추려면 인터페이스를 구현해서 실체화시켜야 하는데 메소드 1개만을 지닌 클래스를 인터페이스로 분할하는 것이 과연 좋은 구조인가🥲

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
