### PR TITLE
[SCRUM-72] 유저 계정 잠금 활성화 및 비활성화 , 회원 탈퇴

### DIFF
--- a/src/main/java/example/demo/domain/member/Member.java
+++ b/src/main/java/example/demo/domain/member/Member.java
@@ -1,6 +1,7 @@
 package example.demo.domain.member;
 
 import example.demo.domain.BaseEntity;
+import example.demo.domain.chat.ChatRoom;
 import example.demo.domain.company.Company;
 import example.demo.domain.member.dto.request.MemberRequestDto;
 import jakarta.persistence.*;
@@ -8,6 +9,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -43,7 +47,6 @@ public class Member extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id")
     private Company company;
-
     public Member(String email, String userName, String password, MemberStatus memberStatus, String phoneNumber, String companyPosition,Company company) {
         this.email = email;
         this.userName = userName;

--- a/src/main/java/example/demo/domain/member/Member.java
+++ b/src/main/java/example/demo/domain/member/Member.java
@@ -86,4 +86,9 @@ public class Member extends BaseEntity {
         this.password = password;
     }
     public void setMemberId(Long memberId){this.memberId=memberId;}
+
+    //멤버의 Lock여부 변경
+    public void changeMemberLock(boolean type){
+        this.accountLocked=type;
+    }
 }

--- a/src/main/java/example/demo/domain/member/dto/response/CompanyEmployeeResponseDto.java
+++ b/src/main/java/example/demo/domain/member/dto/response/CompanyEmployeeResponseDto.java
@@ -9,12 +9,14 @@ public class CompanyEmployeeResponseDto {
     private String companyPosition;
     private String name;
     private String email;
+    private Long memberId;
 
     @QueryProjection
     @Builder
-    public CompanyEmployeeResponseDto(String companyPosition, String name, String email) {
+    public CompanyEmployeeResponseDto(String companyPosition, String name, String email,Long memberId) {
         this.companyPosition = companyPosition;
         this.name = name;
         this.email = email;
+        this.memberId=memberId;
     }
 }

--- a/src/main/java/example/demo/domain/member/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/example/demo/domain/member/repository/MemberCustomRepositoryImpl.java
@@ -69,7 +69,8 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .select(new QCompanyEmployeeResponseDto(
                         member.companyPosition,
                         member.userName,
-                        member.email
+                        member.email,
+                        member.memberId
                 ))
                 .from(member)
                 .leftJoin(member.company, company)

--- a/src/main/java/example/demo/security/auth/AuthErrorCode.java
+++ b/src/main/java/example/demo/security/auth/AuthErrorCode.java
@@ -17,7 +17,9 @@ public enum AuthErrorCode implements ErrorCode {
     NOT_AUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED,"인증된 유저가 아닙니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_GATEWAY,"유효하지 않은 리프레시 토큰값입니다."),
     CAN_NOT_LOCKED_MANAGER(HttpStatus.BAD_REQUEST,"관리자의 계정은 잠금처리할 수 없습니다."),
-    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST,"올바르지 않은 타입 값입니다.");
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST,"올바르지 않은 타입 값입니다."),
+    IS_LOCKED(HttpStatus.BAD_REQUEST,"해당 계정이 잠긴 상태입니다."),
+    IS_NOT_LOCKED(HttpStatus.BAD_REQUEST,"해당 계정은 잠긴 상태가 아닙니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/example/demo/security/auth/AuthErrorCode.java
+++ b/src/main/java/example/demo/security/auth/AuthErrorCode.java
@@ -15,7 +15,8 @@ public enum AuthErrorCode implements ErrorCode {
     ACCOUNT_LOCKED(HttpStatus.LOCKED,"계정이 잠겼습니다.관리자에게 문의해주세요."),
     NO_AUTHORITIES(HttpStatus.FORBIDDEN,"권한이 없습니다."),
     NOT_AUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED,"인증된 유저가 아닙니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_GATEWAY,"유효하지 않은 리프레시 토큰값입니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_GATEWAY,"유효하지 않은 리프레시 토큰값입니다."),
+    CAN_NOT_LOCKED_MANAGER(HttpStatus.BAD_REQUEST,"관리자의 계정은 잠금처리할 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/example/demo/security/auth/AuthErrorCode.java
+++ b/src/main/java/example/demo/security/auth/AuthErrorCode.java
@@ -16,7 +16,8 @@ public enum AuthErrorCode implements ErrorCode {
     NO_AUTHORITIES(HttpStatus.FORBIDDEN,"권한이 없습니다."),
     NOT_AUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED,"인증된 유저가 아닙니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_GATEWAY,"유효하지 않은 리프레시 토큰값입니다."),
-    CAN_NOT_LOCKED_MANAGER(HttpStatus.BAD_REQUEST,"관리자의 계정은 잠금처리할 수 없습니다.");
+    CAN_NOT_LOCKED_MANAGER(HttpStatus.BAD_REQUEST,"관리자의 계정은 잠금처리할 수 없습니다."),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST,"올바르지 않은 타입 값입니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/example/demo/security/auth/CustomMemberDetailService.java
+++ b/src/main/java/example/demo/security/auth/CustomMemberDetailService.java
@@ -5,6 +5,7 @@ import example.demo.domain.member.repository.MemberRepository;
 import example.demo.error.RestApiException;
 import example.demo.security.auth.dto.CustomMemberInfoDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,6 +21,10 @@ public class CustomMemberDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
         Member member=memberRepository.findById(Long.parseLong(memberId))
                 .orElseThrow(()->new RestApiException(AuthErrorCode.NOT_EXIST_MEMBER));
+        //유저의 잠금 상태 확인
+        if(member.isAccountLocked()){
+            throw new LockedException("계정이 잠겨있습니다. 관리자에게 문의해주세요.");
+        }
         CustomMemberInfoDto dto=CustomMemberInfoDto.builder()
                 .email(member.getEmail())
                 .accountLocked(member.isAccountLocked())

--- a/src/main/java/example/demo/security/auth/api/AuthApiController.java
+++ b/src/main/java/example/demo/security/auth/api/AuthApiController.java
@@ -44,8 +44,9 @@ public class AuthApiController {
 
     @PutMapping("locked")
     public ResponseEntity<?> lockingCompanyEmployee(@RequestHeader("Authorization")String token,
-                                                    @RequestParam("memberId")Long memberId){
-        authService.locking(token,memberId);
+                                                    @RequestParam("memberId")Long memberId,
+                                                    @RequestParam("type")String type){
+        authService.locking(token,memberId,type);
         return ResponseEntity.ok("해당 회원의 계정을 잠금 처리했습니다.");
     }
 }

--- a/src/main/java/example/demo/security/auth/api/AuthApiController.java
+++ b/src/main/java/example/demo/security/auth/api/AuthApiController.java
@@ -41,4 +41,11 @@ public class AuthApiController {
         authService.secessionMember(token);
         return ResponseEntity.ok("탈퇴가 완료되었습니다.");
     }
+
+    @PutMapping("locked")
+    public ResponseEntity<?> lockingCompanyEmployee(@RequestHeader("Authorization")String token,
+                                                    @RequestParam("memberId")Long memberId){
+        authService.locking(token,memberId);
+        return ResponseEntity.ok("해당 회원의 계정을 잠금 처리했습니다.");
+    }
 }

--- a/src/main/java/example/demo/security/auth/api/AuthApiController.java
+++ b/src/main/java/example/demo/security/auth/api/AuthApiController.java
@@ -35,4 +35,10 @@ public class AuthApiController {
         AccessTokenResponseDto accessTokenResponseDto= authService.refreshAccessToken(refreshToken,response);
         return ResponseEntity.ok(accessTokenResponseDto);
     }
+
+    @DeleteMapping("secession")
+    public ResponseEntity<?> deleteMember(@RequestHeader("Authorization")String token){
+        authService.secessionMember(token);
+        return ResponseEntity.ok("탈퇴가 완료되었습니다.");
+    }
 }

--- a/src/main/java/example/demo/security/auth/api/AuthApiController.java
+++ b/src/main/java/example/demo/security/auth/api/AuthApiController.java
@@ -47,6 +47,10 @@ public class AuthApiController {
                                                     @RequestParam("memberId")Long memberId,
                                                     @RequestParam("type")String type){
         authService.locking(token,memberId,type);
-        return ResponseEntity.ok("해당 회원의 계정을 잠금 처리했습니다.");
+        if (type.equals("true")){
+            return ResponseEntity.ok("해당 회원의 계정을 잠금 처리했습니다.");
+        }else {
+            return ResponseEntity.ok("해당 회원의 계정을 잠금 해제 처리했습니다.");
+        }
     }
 }

--- a/src/main/java/example/demo/security/auth/api/AuthService.java
+++ b/src/main/java/example/demo/security/auth/api/AuthService.java
@@ -7,4 +7,5 @@ import jakarta.servlet.http.HttpServletResponse;
 public interface AuthService {
     AccessTokenResponseDto loginMember(MemberLoginDto loginDto, HttpServletResponse response);
     AccessTokenResponseDto refreshAccessToken(String refreshToken,HttpServletResponse response);
+    void secessionMember(String token);
 }

--- a/src/main/java/example/demo/security/auth/api/AuthService.java
+++ b/src/main/java/example/demo/security/auth/api/AuthService.java
@@ -8,4 +8,5 @@ public interface AuthService {
     AccessTokenResponseDto loginMember(MemberLoginDto loginDto, HttpServletResponse response);
     AccessTokenResponseDto refreshAccessToken(String refreshToken,HttpServletResponse response);
     void secessionMember(String token);
+    void locking(String token, Long memberId);
 }

--- a/src/main/java/example/demo/security/auth/api/AuthService.java
+++ b/src/main/java/example/demo/security/auth/api/AuthService.java
@@ -8,5 +8,5 @@ public interface AuthService {
     AccessTokenResponseDto loginMember(MemberLoginDto loginDto, HttpServletResponse response);
     AccessTokenResponseDto refreshAccessToken(String refreshToken,HttpServletResponse response);
     void secessionMember(String token);
-    void locking(String token, Long memberId);
+    void locking(String token, Long memberId,String type);
 }

--- a/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
+++ b/src/main/java/example/demo/security/auth/api/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package example.demo.security.auth.api;
 import example.demo.domain.member.Member;
 import example.demo.domain.member.MemberErrorCode;
 import example.demo.domain.member.repository.MemberRepository;
+import example.demo.error.CommonErrorCode;
 import example.demo.error.RestApiException;
 import example.demo.security.auth.AuthErrorCode;
 import example.demo.security.auth.dto.AccessTokenResponseDto;
@@ -105,6 +106,14 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(newAccessToken)
                 .message("엑세스 토큰 재발행 성공")
                 .build();
+    }
+
+    @Override
+    public void secessionMember(String token) {
+        Long memberId=jwtUtil.getMemberId(token);
+        Member findMember=memberRepository.findById(memberId)
+                .orElseThrow(()->new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        memberRepository.delete(findMember);
     }
 
     private static void setRefreshToken(String refreshToken, HttpServletResponse response) {

--- a/src/main/java/example/demo/security/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/example/demo/security/config/CustomAuthenticationEntryPoint.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -19,7 +20,13 @@ import java.io.IOException;
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        log.error("Not Authenticated Request",authException);
-        throw new RestApiException(AuthErrorCode.NOT_AUTHENTICATED_REQUEST);
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+
+        //계정이 잠긴 경우
+        if(authException instanceof LockedException){
+            throw new RestApiException(AuthErrorCode.ACCOUNT_LOCKED);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#65 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 회원 계정 탈퇴 구현
- MANAGER 권한을 가진 회사의 관리자가 같은 회사의 EMPLOYEE 직원 계정을 잠금 처리 구현
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
